### PR TITLE
Add Render Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ capture- // whitespace stripped
 ```javascript
 include
 includewith    // Theme Tag {% include %} with parameters
+render
+renderwith    // Theme Tag {% render %} with parameters
 section
 raw
 layout

--- a/snippets/liquid.json
+++ b/snippets/liquid.json
@@ -173,6 +173,20 @@
             "{% include '${1:snippet}', ${2:variable}: ${3:value} %}"
         ]
     },
+    "Tag render": {
+        "prefix": "render",
+        "description": "Theme tag: render",
+        "body": [
+            "{% render '${1:snippet}' %}"
+        ]
+    },
+    "Tag render with parameters": {
+        "prefix": "renderwith",
+        "description": "Theme tag: render with parameters",
+        "body": [
+            "{% render '${1:snippet}', ${2:variable}: ${3:value} %}"
+        ]
+    },
     "Tag section": {
         "prefix": "section",
         "description": "Theme tag: section",


### PR DESCRIPTION
Shopify [deprecated](https://developers.shopify.com/changelog/deprecating-the-include-liquid-tag-and-introducing-the-render-tag) the `{% include %}` theme tag in November 2019, replacing it with the new `{% render %}` tag. It [functions much in the same way](https://help.shopify.com/en/themes/liquid/tags/theme-tags#render) as include did, however it's not aware of your liquid template & vars unless they are explicitly passed, thereby increasing performance (per Shopify). 

This change adds support for Render theme tag in a similar fashion to include, along with the `renderwith` shortcut to add params.